### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Net::IP::Parse",
+    "license" : "BSD-2-Clause",
     "version" : "0.0.3",
     "description" : "Types for IP addresses and manipulation methods.",
     "author" : "Brad Clawsie",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license