### PR TITLE
Support for "IPv4 in IPv6 String" format

### DIFF
--- a/lib/Net/IP/Parse.pm6
+++ b/lib/Net/IP/Parse.pm6
@@ -100,10 +100,10 @@ my package EXPORT::DEFAULT {
         has UInt8 @.octets;
         has IPVersion $.version = Nil;
         has Str $.zone_id = Nil;
-        
+
         multi submethod BUILD(Str:D :$addr) {
             if ($addr ~~ /\./) {
-                my $matches = (rx|^(\d+).(\d+).(\d+).(\d+)$|).ACCEPTS: $addr;
+                my $matches = (rx|^(?:::ffff:)?(\d+).(\d+).(\d+).(\d+)$|).ACCEPTS: $addr;
                 X::Net::IP::Parse::Err.new(input=>$addr).throw unless so $matches;
                 my UInt8 @octets = $matches.list.map: {.UInt};
                 self.BUILD(octets=>@octets);


### PR DESCRIPTION
Wikipedia states (or used to state, at least) that strings of the form "::ffff:1.2.3.4" are perfectly cromulent representations of an IPv4 string padded to appear in the IPv6 space. This is an attempt to make the existing code be able to accept strings like that.