### PR TITLE
Lists cannot be parametarized

### DIFF
--- a/lib/Net/IP/Parse.pm6
+++ b/lib/Net/IP/Parse.pm6
@@ -88,7 +88,7 @@ my package EXPORT::DEFAULT {
     
     subset IPVersion of Int where * == 4|6;
 
-    my sub word-bytes(UInt16:D $word --> List:D[UInt8]) {
+    my sub word-bytes(UInt16:D $word --> Positional:D[UInt8]) {
         return (($word +> 8) +& 0xff),($word +& 0xff); 
     }
     


### PR DESCRIPTION
The only reason the code doesn't explode is because parametarization of DefiniteHOW types silently fails.